### PR TITLE
Typo

### DIFF
--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/08 - Battle For Azeroth/Freehold.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/08 - Battle For Azeroth/Freehold.lua
@@ -55,7 +55,7 @@ root(ROOTS.Instances, expansion(EXPANSION.BFA, bubbleDown({ ["timeline"] = { ADD
 						126847,	-- Captain Raoul
 					},
 					["groups"] = {
-						i(159132),	-- Jolly's Boot Daggeer
+						i(159132),	-- Jolly's Boot Dagger
 						i(159130),	-- Captain's Diplomacy
 						i(158311),	-- Concealed Fencing Plates
 						i(159356),	-- Raoul's Barrelhook Bracers
@@ -126,7 +126,7 @@ root(ROOTS.Instances, expansion(EXPANSION.BFA, bubbleDown({ ["timeline"] = { ADD
 							126847,	-- Captain Raoul
 						},
 						["groups"] = {
-							i(159132),	-- Jolly's Boot Daggeer
+							i(159132),	-- Jolly's Boot Dagger
 							i(159130),	-- Captain's Diplomacy
 							i(158311),	-- Concealed Fencing Plates
 							i(159356),	-- Raoul's Barrelhook Bracers
@@ -201,7 +201,7 @@ root(ROOTS.Instances, expansion(EXPANSION.BFA, bubbleDown({ ["timeline"] = { ADD
 							126847,	-- Captain Raoul
 						},
 						["groups"] = {
-							i(159132),	-- Jolly's Boot Daggeer
+							i(159132),	-- Jolly's Boot Dagger
 							i(159130),	-- Captain's Diplomacy
 							i(158311),	-- Concealed Fencing Plates
 							i(159356),	-- Raoul's Barrelhook Bracers

--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/13 Shadowlands/Zereth Mortis/Quests.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/13 Shadowlands/Zereth Mortis/Quests.lua
@@ -911,7 +911,7 @@ root(ROOTS.Zones, m(SHADOWLANDS, bubbleDown({ ["timeline"] = { ADDED_9_2_0 } }, 
 					},
 				}),
 			}),
-			header(HEADERS.AchCriteria, 15515.02, {	-- Not Al Are Lost
+			header(HEADERS.AchCriteria, 15515.02, {	-- Not All Are Lost
 				q(64771, {	-- Enlightened Exodus
 					["sourceQuests"] = { 64958 },	-- The Forces Gather
 					["provider"] = { "n", 181003 },	-- Al'dalil

--- a/.contrib/Parser/DATAS/17 - NYI/NYI Professions/NYI Alchemy.lua
+++ b/.contrib/Parser/DATAS/17 - NYI/NYI Professions/NYI Alchemy.lua
@@ -107,7 +107,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 				n(P1xx, {
 					r(11447),	-- Elixir of Waterwalking
 					r(22430),	-- Refined Scale of Onyxia
-					-- With SpellID attched
+					-- With SpellID attached
 					i(5641),	-- Recipe: Cowardly Flight Potion
 					i(2556),	-- Recipe: Elixir of Tongues
 					i(13500),	-- Recipe: Greater Holy Protection Potion
@@ -116,7 +116,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 			expansion(EXPANSION.TBC, {
 				-- 2.3.0
 				expansion(EXPANSION.TBC, patch(3,0), bubbleDownSelf({ ["timeline"] = { CREATED_2_3_0 } }, {
-					-- Without SpellID attched
+					-- Without SpellID attached
 					i(34481),	-- Recipe: Mad Alchemist's Potion
 				})),
 			}),
@@ -135,7 +135,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 
 				-- 4.3.0
 				expansion(EXPANSION.CATA, patch(3,0), bubbleDownSelf({ ["timeline"] = { CREATED_4_3_0 } }, {
-					-- With SpellID attched
+					-- With SpellID attached
 					i(71955),	-- Recipe: Transmute Deepholm Iolite
 					i(71956),	-- Recipe: Transmute Elven Peridot
 					i(71958),	-- Recipe: Transmute Lava Coral
@@ -154,7 +154,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 					r(156575),	-- Greater Draenor Armor Flask
 					r(156574),	-- Greater Draenor Spirit Flask
 					r(156583),	-- Draenor Treasure Finding Potion
-					-- With SpellID attched
+					-- With SpellID attached
 					i(112049),	-- Recipe: Alchemical Catalyst - Fireweed
 					i(112050),	-- Recipe: Alchemical Catalyst - Flytrap
 					i(112054),	-- Recipe: Alchemical Catalyst - Lotus
@@ -164,7 +164,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 					i(113625),	-- Recipe: Draenor Versatility Flask
 					i(112032),	-- Recipe: Greater Draenor Haste Flask
 					i(113626),	-- Recipe: Greater Draenor Versatility Flask
-					-- Without SpellID attched
+					-- Without SpellID attached
 					i(112052),	-- Recipe: Alchemical Catalyst - Arrowbloom
 					i(112043),	-- Recipe: Draenic Mana Potion
 					i(112022),	-- Recipe: Mighty Shadow Protection Potion
@@ -194,7 +194,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 				expansion(EXPANSION.BFA, patch(2,0), bubbleDownSelf({ ["timeline"] = { CREATED_8_2_0 } }, {
 					r(298737),	-- Potion of Reconstitution [Rank 1]
 					r(298738),	-- Potion of Reconstitution [Rank 2]
-					-- With SpellID attched
+					-- With SpellID attached
 					i(169493),	-- Recipe: Potion of Reconstitution [Rank 3]
 					i(169601),	-- Recipe: Potion of Reconstitution [Rank 3]
 				})),
@@ -215,7 +215,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 					r(307110),	-- Unknown
 					r(307111),	-- Unknown
 					r(307112),	-- Unknown
-					-- Without SpellID attched
+					-- Without SpellID attached
 					i(183868),	-- [DNT][REUSE ME] Recipe: Crafter's Mark III
 					i(182665),	-- Recipe: Sins to Virtue
 				})),
@@ -231,7 +231,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 					r(371635),	-- Demonstration Item Recipe
 					r(370771),	-- Dragon Isles Alchemy Troubleshooting Test Recipe (DNT)
 					r(382571),	-- Opening
-					-- With SpellID attched
+					-- With SpellID attached
 					i(191598),	-- Recipe: Alchemical Flavor Pocket (RECIPE!)
 					i(191453),	-- Recipe: Frostfire Potion of Draconic Vigor (RECIPE!)
 					i(191457),	-- Recipe: Potion of Burning Purification (RECIPE!)
@@ -294,7 +294,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 					r(433606),	-- Unknown
 					r(433607),	-- Unknown
 					r(433608),	-- Unknown
-					-- With SpellID attched
+					-- With SpellID attached
 					i(224019),	-- Recipe: Vicious Flask of Manifested Fury (RECIPE!)
 				})),
 			}),

--- a/.contrib/Parser/DATAS/17 - NYI/NYI Professions/NYI Blacksmithing.lua
+++ b/.contrib/Parser/DATAS/17 - NYI/NYI Professions/NYI Blacksmithing.lua
@@ -768,7 +768,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 				n(P1xx, {
 					r(6470),	-- Tiny Bronze Key
 					r(6471),	-- Tiny Iron Key
-					-- With SpellID attched
+					-- With SpellID attached
 					i(12831),	-- Plans: Blood Talon
 					i(12818),	-- Plans: Inlaid Thorium Hammer
 					i(6734),	-- Plans: Ironforge Chain
@@ -955,7 +955,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 					r(153657),	-- Peerless Draenic Steel Warboots
 					r(153663),	-- Peerless Draenic Steel Wristwraps
 					r(171718),	-- Truesteel Ingot
-					-- With SpellID attched
+					-- With SpellID attached
 					i(108421),	-- Plans: Blackrock Crucible
 					-- Without SpellID attached
 					i(116727),	-- Plans: Smoldering Breastplate
@@ -1109,7 +1109,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 					r(371396),	-- Draconium Repair Hammer
 					r(382579),	-- Opening
 					r(376698),	-- Wisp of Tyr
-					-- With SpellID attched
+					-- With SpellID attached
 					i(194487),	-- Plans: Pauldrons of the Dragon
 					i(194488),	-- Plans: Traitorous Primal Gauntlets of the Dragon
 					-- Without SpellID attached

--- a/.contrib/Parser/DATAS/17 - NYI/NYI Professions/NYI Jewelcrafting.lua
+++ b/.contrib/Parser/DATAS/17 - NYI/NYI Professions/NYI Jewelcrafting.lua
@@ -103,7 +103,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 			expansion(EXPANSION.TBC, {
 				-- 2.0.5
 				expansion(EXPANSION.TBC, patch(0,5), bubbleDownSelf({ ["timeline"] = { CREATED_2_0_5 } }, {
-					-- With SpellID attched
+					-- With SpellID attached
 					i(21958),	-- Design: Arcanite Sword Pendant
 					i(21959),	-- Design: Blood Crown
 					i(21951),	-- Design: Cut Azerothian Diamond
@@ -114,13 +114,13 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 
 				-- 2.1.3
 				expansion(EXPANSION.TBC, patch(1,3), bubbleDownSelf({ ["timeline"] = { CREATED_2_1_3 } }, {
-					-- With SpellID attched
+					-- With SpellID attached
 					i(25888),	-- Design: Primal Stone Statue
 				})),
 
 				-- 2.4.0
 				expansion(EXPANSION.TBC, patch(4,0), bubbleDownSelf({ ["timeline"] = { CREATED_2_4_0 } }, {
-					-- Without SpellID attched
+					-- Without SpellID attached
 					i(35533),	-- Design: Amulet of Flowing Life
 					i(35534),	-- Design: Hard Khorium Band
 					i(35535),	-- Design: Hard Khorium Choker
@@ -132,7 +132,7 @@ root(ROOTS.NeverImplemented, n(PROFESSIONS, {
 			expansion(EXPANSION.WRATH, {
 				-- 3.0.2
 				expansion(EXPANSION.WRATH, patch(0,2), bubbleDownSelf({ ["timeline"] = { CREATED_3_0_2 } }, {
-					-- Without SpellID attched
+					-- Without SpellID attached
 					i(41408),	-- ZZOLD Design: Austere Earthsiege Diamond
 					i(41412),	-- ZZOLD Design: Beaming Earthsiege Diamond
 					i(41404),	-- ZZOLD Design: Bracing Earthsiege Diamond

--- a/.contrib/Parser/DATAS/21 - Holidays/Timewalking.lua
+++ b/.contrib/Parser/DATAS/21 - Holidays/Timewalking.lua
@@ -917,7 +917,7 @@ root(ROOTS.Holidays, n(TIMEWALKING_HEADER, applyevent(EVENTS.TIMEWALKING_CLASSIC
 					i(151460),	-- Farraki Ceremonial Robes
 					i(232903),	-- Jang'thraze the Protector
 					i(9478),	-- Ripsaw
-					i(232904),	-- Sul'thraze the Lashe
+					i(232904),	-- Sul'thraze the Lasher
 					i(9477),	-- The Chief's Enforcer
 					i(151461),	-- Ukorz's Chain Leggings
 				},
@@ -983,7 +983,7 @@ root(ROOTS.Holidays, n(TIMEWALKING_HEADER, applyevent(EVENTS.TIMEWALKING_OUTLAND
 							i(133543),	-- Infinite Timereaver (MOUNT!)
 							-- Archimonde
 							i(171942),	-- Cowl of Absolution
-							i(171941),	-- Cowl o the Tempest
+							i(171941),	-- Cowl of the Tempest
 							i(171943),	-- Hood of Absolution
 							i(171940),	-- Hood of the Malefic
 							i(171929),	-- Lightbringer Faceguard
@@ -1196,7 +1196,7 @@ root(ROOTS.Holidays, n(TIMEWALKING_HEADER, applyevent(EVENTS.TIMEWALKING_OUTLAND
 						i(232001, {	-- Blazing Skyhawk Repeater
 							["cost"] = {{"c", TIMEWARPED_BADGE, 1800}},
 						}),
-						i(232061, {	-- Cenarion Gaurdian's Stave
+						i(232061, {	-- Cenarion Guardian's Stave
 							["cost"] = {{"c", TIMEWARPED_BADGE, 1800}},
 						}),
 						i(232023, {	-- Chilled Obsidian Dragon's Tooth
@@ -4000,7 +4000,7 @@ root(ROOTS.Holidays, n(TIMEWALKING_HEADER, applyevent(EVENTS.TIMEWALKING_CATACLY
 							["cost"] = {{ "c", TIMEWARPED_BADGE, 1200 }},
 							["timeline"] = { ADDED_11_2_0 },
 						}),
-						i(244648, {	-- Scipture of the Scarlet High Priest
+						i(244648, {	-- Scripture of the Scarlet High Priest
 							["cost"] = {{ "c", TIMEWARPED_BADGE, 1200 }},
 							["timeline"] = { ADDED_11_2_0 },
 						}),
@@ -7152,7 +7152,7 @@ root(ROOTS.Holidays, n(TIMEWALKING_HEADER, applyevent(EVENTS.TIMEWALKING_BATTLE_
 					126847,	-- Captain Raoul
 				},
 				["sym"] = {{"select", "modItemID",
-					modItemId(159132,1),	-- Jolly's Boot Daggeer
+					modItemId(159132,1),	-- Jolly's Boot Dagger
 					modItemId(159130,1),	-- Captain's Diplomacy
 					modItemId(158311,1),	-- Concealed Fencing Plates
 					modItemId(159356,1),	-- Raoul's Barrelhook Bracers

--- a/.contrib/Parser/DATAS/21 - Holidays/WoW Anniversary.lua
+++ b/.contrib/Parser/DATAS/21 - Holidays/WoW Anniversary.lua
@@ -1075,7 +1075,7 @@ root(ROOTS.Holidays, applyevent(EVENTS.WOW_ANNIVERSARY, n(WOW_ANNIVERSARY_ROOT, 
 									--	ach(695),	-- The Battle for Mount Hyjal
 									-- Old Token Items
 									i(171942),	-- Cowl of Absolution
-									i(171941),	-- Cowl o the Tempest
+									i(171941),	-- Cowl of the Tempest
 									i(171943),	-- Hood of Absolution
 									i(171940),	-- Hood of the Malefic
 									i(171929),	-- Lightbringer Faceguard


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multiple typos in item names and descriptions (e.g., "Sul'thraze the Lasher", "Cowl of the Tempest", "Cenarion Guardian's Stave", "Scripture of the Scarlet High Priest", "Jolly's Boot Dagger").
  * Fixed an achievement header ("Not All Are Lost").
  * Corrected repeated comment typos ("attched" → "attached") in profession and recipe entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->